### PR TITLE
Jellyfin: Add ability to run on host network

### DIFF
--- a/jellyfin/README.md
+++ b/jellyfin/README.md
@@ -67,6 +67,7 @@ The following tables lists the configurable parameters of the chart and their de
 | `nodeSelector` | Node labels for pod assignment | `{}` |
 | `tolerations` | Tolerations for pod assignment | `[]` |
 | `affinity` | Map of node/pod affinities | `{}` |
+| `hostNetwork` | Run pods in host network | `false` |
 | `persistence.config.enabled` | Enable persistence for config storage | `false` |
 | `persistence.config.storageClass` | Specify the `storageClass` used to provision the config volume | `nil` |
 | `persistence.config.existingClaim` | Use a existing PVC for config which must be created manually before bound | `nil` |

--- a/jellyfin/templates/statefulset.yaml
+++ b/jellyfin/templates/statefulset.yaml
@@ -60,6 +60,7 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+      hostNetwork: {{ .Values.hostNetwork }}
       volumes:
 {{- if and .Values.persistence.config.enabled .Values.persistence.config.existingClaim }}
         - name: config

--- a/jellyfin/values.yaml
+++ b/jellyfin/values.yaml
@@ -105,6 +105,8 @@ tolerations: []
 
 affinity: {}
 
+hostNetwork: false
+
 jellyfin: {}
   # see https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
   # timezone: UTC


### PR DESCRIPTION
I came across your helm chart for Jellyfin and I really liked it except I want to run it on host network to be able to use DLNA. The default value is still `false` for backwards compatibility.