### PR TITLE
Template for extra volume mounts

### DIFF
--- a/transmission-openvpn/README.md
+++ b/transmission-openvpn/README.md
@@ -73,6 +73,8 @@ The following tables lists the configurable parameters of the chart and their de
 | `persistence.data.accessModes` | Access modes of data volume  | `["ReadWriteOnce"]` |
 | `persistence.data.size` | Size for the PV | `64Gi` |
 | `dataVolume` | An alternative data volume definition | `{}` |
+| `extraVolumes` | Specify additional volumes to attach to the pod | `{}` |
+| `extraVolumeMounts` | Specify additional volume mounts for the pod | `{}` |
 | `env` | The **non-sensitive** environment variables to configure the application. See the possible configuration here: https://haugene.github.io/docker-transmission-openvpn/arguments/ | `{}` |
 | `secretEnv` | The **sensitive** environment variables to configure the application. See the possible configuration here: https://haugene.github.io/docker-transmission-openvpn/arguments/ | `{}` |
 | `customProvider.enabled` | Use a custom OpenVPN provider service. More info: https://haugene.github.io/docker-transmission-openvpn/supported-providers/#using_a_custom_provider | `false` |

--- a/transmission-openvpn/templates/statefulset.yaml
+++ b/transmission-openvpn/templates/statefulset.yaml
@@ -57,6 +57,9 @@ spec:
             - mountPath: /etc/openvpn/custom/
               name: custom-provider-config
             {{- end }}
+            {{- if .Values.extraVolumeMounts }}
+{{ toYaml .Values.extraVolumeMounts | indent 12 }}
+            {{- end }}
           envFrom:
             - configMapRef:
                 name: {{ include "transmission-openvpn.fullname" . }}
@@ -102,6 +105,9 @@ spec:
 {{- else }}
         - name: data
           emptyDir: {}
+{{- end }}
+{{- if .Values.extraVolumes }}
+{{ toYaml .Values.extraVolumes | indent 8 }}
 {{- end }}
   volumeClaimTemplates:
 {{- if and .Values.persistence.data.enabled (not .Values.persistence.data.existingClaim) }}

--- a/transmission-openvpn/values.yaml
+++ b/transmission-openvpn/values.yaml
@@ -118,3 +118,12 @@ timezoneMountFromHost:
   name: localtime
 
 dnsConfig: {}
+
+# Arbitrary extra mounts for the pod.
+extraVolumes: {}
+#  - name: media
+#    persistentVolumeClaim:
+#      claimName: my-existing-pvc
+extraVolumeMounts: {}
+#  - mountPath: /mnt/media
+#  name: media


### PR DESCRIPTION
This enables users to specify arbitrary extra volumes to be mounted to
the pod. For example, this satisfies the use case where you want to
download torrents to an existing PVC (perhaps an NFS share), but you
don't want to keep Transmission's data there.