### PR TITLE
feat(transmission-openvpn): add support for additional labels

### DIFF
--- a/transmission-openvpn/templates/configmap.yaml
+++ b/transmission-openvpn/templates/configmap.yaml
@@ -4,5 +4,8 @@ metadata:
   name: {{ include "transmission-openvpn.fullname" . }}
   labels:
     {{- include "transmission-openvpn.labels" . | nindent 4 }}
+    {{- with .Values.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 data:
   {{- toYaml .Values.env | nindent 2 }}

--- a/transmission-openvpn/templates/deployment.yaml
+++ b/transmission-openvpn/templates/deployment.yaml
@@ -4,6 +4,9 @@ metadata:
   name: {{ include "transmission-openvpn.fullname" . }}
   labels:
     {{- include "transmission-openvpn.labels" . | nindent 4 }}
+    {{- with .Values.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   {{- with .Values.strategy }}
   strategy:

--- a/transmission-openvpn/templates/ingress.yaml
+++ b/transmission-openvpn/templates/ingress.yaml
@@ -18,6 +18,9 @@ metadata:
   name: {{ $fullName }}
   labels:
     {{- include "transmission-openvpn.labels" . | nindent 4 }}
+    {{- with .Values.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- with .Values.ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/transmission-openvpn/templates/pvc.yaml
+++ b/transmission-openvpn/templates/pvc.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ include "transmission-openvpn.fullname" . }}
   labels:
     {{- include "transmission-openvpn.labels" . | nindent 4 }}
+    {{- with .Values.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- with .Values.persistence.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/transmission-openvpn/templates/secret.yaml
+++ b/transmission-openvpn/templates/secret.yaml
@@ -4,6 +4,9 @@ metadata:
   name: {{ include "transmission-openvpn.fullname" . }}
   labels:
     {{- include "transmission-openvpn.labels" . | nindent 4 }}
+    {{- with .Values.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 data:
   {{- range $k, $v := .Values.secretEnv }}
   {{ $k }}: {{ $v | b64enc }}

--- a/transmission-openvpn/templates/service.yaml
+++ b/transmission-openvpn/templates/service.yaml
@@ -4,6 +4,9 @@ metadata:
   name: {{ include "transmission-openvpn.fullname" . }}
   labels:
     {{- include "transmission-openvpn.labels" . | nindent 4 }}
+    {{- with .Values.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/transmission-openvpn/templates/serviceaccount.yaml
+++ b/transmission-openvpn/templates/serviceaccount.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ include "transmission-openvpn.serviceAccountName" . }}
   labels:
     {{- include "transmission-openvpn.labels" . | nindent 4 }}
+    {{- with .Values.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- with .Values.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/transmission-openvpn/values.yaml
+++ b/transmission-openvpn/values.yaml
@@ -10,6 +10,9 @@ hostPort:
   # -- Host port to bind to
   port: 9091
 
+# -- Additional labels for this chart's resources
+additionalLabels: {}
+
 # -- Additional port definitions for the pod
 additionalPorts: []
 


### PR DESCRIPTION
I have started using your transmission-openvpn (works great!) but noticed it was missing a feature found in many other charts: the ability to add custom labels on the resources declared by this chart.

This PR adds support for this, under the "additionalLabels" key.