### PR TITLE
feat(transmission-openvpn): add volumeName persistence option

### DIFF
--- a/transmission-openvpn/templates/pvc.yaml
+++ b/transmission-openvpn/templates/pvc.yaml
@@ -23,4 +23,7 @@ spec:
   {{- if .Values.persistence.storageClass }}
   storageClassName: {{ .Values.persistence.storageClass }}
   {{- end -}}
+  {{- if .Values.persistence.volumeName }}
+  volumeName: {{ .Values.persistence.volumeName }}
+  {{- end -}}
 {{- end -}}

--- a/transmission-openvpn/values.yaml
+++ b/transmission-openvpn/values.yaml
@@ -112,6 +112,8 @@ persistence:
   existingClaim: ""
   # -- Storage class for the data volume
   storageClass: ""
+  # -- Volume name override for the pvc
+  volumeName: ""
   # -- Annotations for the claim
   annotations: {}
     # helm.sh/resource-policy: keep


### PR DESCRIPTION
This PR adds a "persistence.volumeName" option to the transmission-openvpn chart. This allows setting the volumeName field on the PVC, which can be used to reference existing PVs.