### PR TITLE
Add env values to filebrowser

### DIFF
--- a/filebrowser/templates/configmap.yaml
+++ b/filebrowser/templates/configmap.yaml
@@ -5,5 +5,6 @@ metadata:
   labels:
     {{- include "filebrowser.labels" . | nindent 4 }}
 data:
+  {{- toYaml .Values.env | nindent 2 }}
   settings.json: |
     {{- .Values.config | toPrettyJson | nindent 4 }}

--- a/filebrowser/templates/deployment.yaml
+++ b/filebrowser/templates/deployment.yaml
@@ -49,6 +49,9 @@ spec:
             - mountPath: /rootdir
               name: rootdir
               readOnly: {{ .Values.rootDir.readOnly }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "filebrowser.fullname" . }}
           ports:
             - name: http
               containerPort: {{ .Values.config.port }}

--- a/filebrowser/values.yaml
+++ b/filebrowser/values.yaml
@@ -46,6 +46,12 @@ securityContext: {}
   # runAsNonRoot: true
   # runAsUser: 1000
 
+# -- Non-sensitive environment variables to be set in the pods.
+env: {}
+  # --  map the container's internal user to a user on the host machine
+  # PUID: "1000"
+  # PGID: "1000"
+
 service:
   # -- Kubernetes Service type
   type: ClusterIP


### PR DESCRIPTION
- Allow to use LinuxServer approach to map the container's internal user to a user on the host machine.

see https://filebrowser.org/installation 
  filebrowser is using  PUID  and PGID values as defined in linuxserver
 https://docs.linuxserver.io/general/understanding-puid-and-pgid

For me this change allows to set files ownership to uploaded files  and  control access  mode for 'hostPath' rootDir
