### PR TITLE
Nfs server can be used as rootdir

### DIFF
--- a/filebrowser/README.md
+++ b/filebrowser/README.md
@@ -87,12 +87,14 @@ The following tables lists the configurable parameters of the chart and their de
 | replicaCount | int | `1` | Number of replicas to run. Chart is not designed to scale horizontally, use at your own risk |
 | resources | object | `{}` | The resources to allocate for the container |
 | rootDir.hostPath.path | string | `"/path/on/host"` |  |
+| rootDir.nfs.server | string | `""` |  |
+| rootDir.nfs.path | string | `""` |  |
 | rootDir.pvc.accessModes | list | `["ReadWriteOnce"]` | Access modes for the root directory PVC |
 | rootDir.pvc.existingClaim | string | `""` | Existing claim for the root directory |
 | rootDir.pvc.size | string | `"2Gi"` | Size for the root directory PVC |
 | rootDir.pvc.storageClassName | string | `""` | Storage class name for the root directory PVC |
 | rootDir.readOnly | bool | `false` | Mount the root directory in read-only mode |
-| rootDir.type | string | `"pvc"` | type of rootDir mount. Valid values are [pvc, hostPath, emptyDir] |
+| rootDir.type | string | `"pvc"` | type of rootDir mount. Valid values are [pvc, hostPath, nfs, emptyDir] |
 | securityContext | object | `{}` | The security context for the application container |
 | service.port | int | `80` | Kubernetes Service port |
 | service.type | string | `"ClusterIP"` | Kubernetes Service type |

--- a/filebrowser/templates/deployment.yaml
+++ b/filebrowser/templates/deployment.yaml
@@ -94,6 +94,10 @@ spec:
           {{- else if eq .Values.rootDir.type "hostPath" }}
           hostPath:
             path: {{ .Values.rootDir.hostPath.path }}
+          {{- else if eq .Values.rootDir.type "nfs" }}
+          nfs:
+            server: {{ .Values.rootDir.nfs.server }}
+            path: {{ .Values.rootDir.nfs.path }}
           {{- else }}
           emptyDir: {}
           {{- end }}

--- a/filebrowser/values.yaml
+++ b/filebrowser/values.yaml
@@ -97,12 +97,15 @@ tolerations: []
 affinity: {}
 
 rootDir:
-  # -- type of rootDir mount. Valid values are [pvc, hostPath, emptyDir]
+  # -- type of rootDir mount. Valid values are [pvc, hostPath, nfs, emptyDir]
   type: pvc
   # -- Mount the root directory in read-only mode
   readOnly: false
   hostPath:
     path: /path/on/host
+  nfs:
+    server: ""
+    path: ""
   pvc:
     # -- Existing claim for the root directory
     existingClaim: ""


### PR DESCRIPTION
Thank you for creating this helm chart. I was able to mount my NFS server into the filebrowser pod using the following configurations and browse through the files in the user interface.

```yaml
rootDir:
  type: nfs
  readOnly: true
  nfs:
    server: "<MY_NFS_SERVER>"
    path: "<MY_NFS_SERVER_PATH>"
```
