### PR TITLE
fix: fix the problem that the template will not render .serviceMonito…

### DIFF
--- a/nvidia-gpu-exporter/templates/servicemonitor.yaml
+++ b/nvidia-gpu-exporter/templates/servicemonitor.yaml
@@ -13,6 +13,9 @@ spec:
     - port: http
       path: {{ .Values.telemetryPath }}
       scheme: {{ .Values.serviceMonitor.scheme }}
+      {{- with .Values.serviceMonitor.bearerTokenFile }}
+      bearerTokenFile: {{ . }}
+      {{- end }}
       {{- with .Values.serviceMonitor.interval }}
       interval: {{ . }}
       {{- end }}


### PR DESCRIPTION
I discovered that when using chart utkuozdemir/nvidia-gpu-exporter, the bearerTokenFile in ServiceMonitor will not be rendered even if I set it in values. Therefore I submit this PR to solve the problem.