### PR TITLE
Add runtimeClassName to pod spec template.

### DIFF
--- a/jellyfin/Chart.yaml
+++ b/jellyfin/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: jellyfin
 description: Jellyfin Helm chart
 type: application
-version: 2.0.0
+version: 2.0.1
 appVersion: 10.7.7
 home: https://jellyfin.org
 keywords:

--- a/jellyfin/README.md
+++ b/jellyfin/README.md
@@ -66,6 +66,7 @@ $ helm install my-release utkuozdemir/jellyfin
 | readinessProbe | object | `{"httpGet":{"port":"http"}}` | Pod readiness probe |
 | replicaCount | int | `1` | Number of replicas to run. Chart is not designed to scale horizontally, use at your own risk |
 | resources | object | `{}` | The resource requests and limits of the container |
+| runtimeClass | string | The runtime class to be used for the pod. This is most commonly used to enable the nvidia runtime container for nvenc hardware acceleration in jellyfin. See the [application docs](https://docs.linuxserver.io/images/docker-jellyfin/#nvidia). |
 | secretEnv | object | `{}` | Sensitive environment variables to be set in the pods. See the [application docs](https://docs.linuxserver.io/images/docker-jellyfin) |
 | securityContext | object | `{"capabilities":{"add":["NET_ADMIN"]}}` | Security context for the container. NET_ADMIN capability is required for the VPN to work properly. |
 | service.port | int | `8096` | Port for the service to use |

--- a/jellyfin/templates/deployment.yaml
+++ b/jellyfin/templates/deployment.yaml
@@ -87,6 +87,9 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.runtimeClass }}
+      runtimeClassName: {{ .Values.runtimeClass }}
+      {{- end -}}
       {{- with .Values.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}

--- a/jellyfin/values.yaml
+++ b/jellyfin/values.yaml
@@ -97,6 +97,9 @@ resources: {}
 # -- The node selector for the deployment
 nodeSelector: {}
 
+# -- The runtime class to be used for the pod. See the [application docs](https://docs.linuxserver.io/images/docker-jellyfin/#nvidia).
+runtimeClass: ""
+
 # -- Tolerations for the pod assignment
 tolerations: []
 


### PR DESCRIPTION
This is needed to enable different runtime classes for the pod. In jellyfin's case, the most common reason for this would be to enable the nvidia container runtime, which can allow for nvidia hardware acceleration within jellyfin.